### PR TITLE
Updating charts repository

### DIFF
--- a/airflow/requirements.lock
+++ b/airflow/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
-  repository: https://kubernetes-charts.storage.googleapis.com
+  repository: https://charts.helm.sh/stable
   version: 6.3.12
-digest: sha256:58d88cf56e78b2380091e9e16cc6ccf58b88b3abe4a1886dd47cd9faef5309af
-generated: "2020-06-21T19:11:53.498134738+02:00"
+digest: sha256:c8a555b20090935557573426c7fa8b3b503fd0849111f96e6d6f173e9f54c001
+generated: "2020-11-20T02:28:08.375700243Z"


### PR DESCRIPTION
This change is required in order for the repository reference to marclamberti.github.io/airflow-eks-helm-chart to work out of the box

Motivation: https://helm.sh/blog/new-location-stable-incubator-charts/


@marclamberti , the course is awesome! Glad to be a student!